### PR TITLE
Resolves an issue where Super Payments breaks checkout if disabled

### DIFF
--- a/src/view/frontend/templates/checkout/payment/super-payment-method.phtml
+++ b/src/view/frontend/templates/checkout/payment/super-payment-method.phtml
@@ -19,8 +19,9 @@
         description: '',
 
         init() {
-            this.method.querySelector('label').innerHTML = '';
-
+            if(this.method !== null) {
+                this.method.querySelector('label').innerHTML = '';
+            }
             this.initEvents();
             this.getPaymentHtml();
         },


### PR DESCRIPTION
If like many others you are deploying Super Payments in a dormant state before activating/configuring it, you would not wish for your checkout to be broken until such time as it was configured.